### PR TITLE
🩹 FIxed JS-0081 for reload.js

### DIFF
--- a/commands/reload.js
+++ b/commands/reload.js
@@ -49,7 +49,7 @@ module.exports = {
                 msg.channel
                     .awaitMessages(filter, {
                         max: 0,
-                        time: 05000
+                        time: "05000"
                     })
                     .then(collected => {
                         if (collected) {

--- a/commands/reload.js
+++ b/commands/reload.js
@@ -53,7 +53,7 @@ module.exports = {
                     })
                     .then(collected => {
                         if (collected) {
-                            newProfilePicture = collected.first().content;
+                            let newProfilePicture = collected.first().content;
                             client.user.setAvatar(newProfilePicture)
                             msg.channel.send(`Changed profile picture!`);
                         }


### PR DESCRIPTION
Fixed JS-0081 for reload.js. Basically this makes the octal literal a string not a number
Resolves #1 